### PR TITLE
Replace async/await with then/catch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -682,7 +682,7 @@
     },
     "babel-eslint": {
       "version": "8.2.2",
-      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
       "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Avoids async syntax in browsers without support.