### PR TITLE
make sure we trigger the send event before caching requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,11 +64,11 @@ export default class AutoCheckElement extends HTMLElement {
     body.append('authenticity_token', this.csrf) // eslint-disable-line github/authenticity-token
     body.append('value', this.input.value)
 
+    this.input.dispatchEvent(new CustomEvent('autocheck:send', {detail: {body}, bubbles: true, cancelable: true}))
+
     const id = body.entries ? [...body.entries()].sort().toString() : null
     if (id && id === previousValues.get(this.input)) return
     previousValues.set(this.input, id)
-
-    this.input.dispatchEvent(new CustomEvent('autocheck:send', {detail: {body}, bubbles: true, cancelable: true}))
 
     if (!this.input.value.trim()) {
       this.input.dispatchEvent(new CustomEvent('autocheck:complete', {bubbles: true, cancelable: true}))

--- a/test/test.js
+++ b/test/test.js
@@ -99,5 +99,23 @@ describe('auto-check element', function() {
         done()
       })
     })
+
+    it('emits a send event before checking if there is a duplicate request', function(done) {
+      const autoCheckElement = document.querySelector('auto-check')
+      const input = autoCheckElement.querySelector('input')
+
+      let counter = 2
+      input.addEventListener('autocheck:send', () => {
+        if (counter === 2) {
+          done()
+        } else {
+          counter += 1
+        }
+      })
+
+      input.value = 'hub'
+      autoCheckElement.check()
+      autoCheckElement.check()
+    })
   })
 })


### PR DESCRIPTION
This patch moves the triggering of the `autocheck:send` event so that it happens before we check the request cache for the current request. This gives application code a opportunity to listen to this event and mutating the body before the cache check is made. Mutating the request body is helpful when application code would like, for example, add a pre- or postfix to the request body.

Example of application code listening for the send event.

```js
on('autocheck:send', '.js-check-name', function(event) {
  event.detail.body.append('additionalData', 'foobar')
})
```