### PR TITLE
Rename success payload warning to message

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ check.addEventListener('loadend', function(event) {
   console.log('Network request complete', event)
 })
 check.addEventListener('load', function(event) {
-  console.log('Network succces succeeded', event)
+  console.log('Network request succeeded', event)
 })
 check.addEventListener('error', function(event) {
   console.log('Network request failed', event)

--- a/README.md
+++ b/README.md
@@ -29,15 +29,18 @@ The endpoint should return:
 
 ## Browser support
 
+Browsers without native [custom element support][support] require a [polyfill][].
+
 - Chrome
 - Firefox
-- Safari 9+
+- Safari
 - Internet Explorer 11
 - Microsoft Edge
 
-## Development
+[support]: https://caniuse.com/#feat=custom-elementsv1
+[polyfill]: https://github.com/webcomponents/custom-elements
 
-Clone this repository and run the following to install the dependencies and run the tests.
+## Development
 
 ```
 npm install

--- a/README.md
+++ b/README.md
@@ -27,6 +27,46 @@ The endpoint should return:
  - a 422 HTTP status code if the provided value is invalid.
  - a optional error message in the body and a `Content-Type` header with a value of `text/html; fragment`.
 
+## Events
+
+```js
+const check = document.querySelector('auto-check')
+
+// Network request lifecycle events.
+check.addEventListener('loadstart', function(event) {
+  console.log('Network request started', event)
+})
+check.addEventListener('loadend', function(event) {
+  console.log('Network request complete', event)
+})
+check.addEventListener('load', function(event) {
+  console.log('Network succces succeeded', event)
+})
+check.addEventListener('error', function(event) {
+  console.log('Network request failed', event)
+})
+
+// Auto-check result events.
+const input = check.querySelector('input')
+
+input.addEventListener('autocheck:send', function(event) {
+  console.log('Adding to FormData before network request is sent.')
+  const {body} = event.detail
+  body.append('custom_form_data', 'value')
+})
+input.addEventListener('autocheck:success', function(event) {
+  const {message} = event.detail
+  console.log('Validation passed', message)
+})
+input.addEventListener('autocheck:error', function(event) {
+  const {message} = event.detail
+  console.log('Validation failed', message)
+})
+input.addEventListener('autocheck:complete', function(event) {
+  console.log('Validation complete', event)
+})
+```
+
 ## Browser support
 
 Browsers without native [custom element support][support] require a [polyfill][].

--- a/src/index.js
+++ b/src/index.js
@@ -68,16 +68,16 @@ export default class AutoCheckElement extends HTMLElement {
     if (id && id === previousValues.get(this.input)) return
     previousValues.set(this.input, id)
 
-    this.input.dispatchEvent(new CustomEvent('autocheck:send', {detail: {body}, bubbles: true, cancelable: true}))
+    this.input.dispatchEvent(new CustomEvent('autocheck:send', {detail: {body}, bubbles: true}))
 
     if (!this.input.value.trim()) {
-      this.input.dispatchEvent(new CustomEvent('autocheck:complete', {bubbles: true, cancelable: true}))
+      this.input.dispatchEvent(new CustomEvent('autocheck:complete', {bubbles: true}))
       return
     }
 
     const always = () => {
       this.dispatchEvent(new CustomEvent('loadend'))
-      this.input.dispatchEvent(new CustomEvent('autocheck:complete', {bubbles: true, cancelable: true}))
+      this.input.dispatchEvent(new CustomEvent('autocheck:complete', {bubbles: true}))
     }
 
     this.dispatchEvent(new CustomEvent('loadstart'))
@@ -86,22 +86,12 @@ export default class AutoCheckElement extends HTMLElement {
         this.dispatchEvent(new CustomEvent('load'))
 
         const message = data ? data.trim() : null
-        this.input.dispatchEvent(
-          new CustomEvent('autocheck:success', {
-            detail: {message},
-            bubbles: true,
-            cancelable: true
-          })
-        )
+        this.input.dispatchEvent(new CustomEvent('autocheck:success', {detail: {message}, bubbles: true}))
       })
       .catch(error => {
         this.dispatchEvent(new CustomEvent('error'))
         this.input.dispatchEvent(
-          new CustomEvent('autocheck:error', {
-            detail: {message: errorMessage(error)},
-            bubbles: true,
-            cancelable: true
-          })
+          new CustomEvent('autocheck:error', {detail: {message: errorMessage(error)}, bubbles: true})
         )
       })
       .then(always, always)

--- a/src/index.js
+++ b/src/index.js
@@ -85,10 +85,10 @@ export default class AutoCheckElement extends HTMLElement {
       .then(data => {
         this.dispatchEvent(new CustomEvent('load'))
 
-        const warning = data ? data.trim() : null
+        const message = data ? data.trim() : null
         this.input.dispatchEvent(
           new CustomEvent('autocheck:success', {
-            detail: {warning},
+            detail: {message},
             bubbles: true,
             cancelable: true
           })

--- a/test/test.js
+++ b/test/test.js
@@ -52,13 +52,13 @@ describe('auto-check element', function() {
       })
     })
 
-    it('emits a success event with warning when server returns a non error response', function() {
+    it('emits a success event with message when server returns a non error response', function() {
       return new Promise(resolve => {
         const input = document.querySelector('input')
         input.value = 'hub'
         input.dispatchEvent(new InputEvent('change'))
         input.addEventListener('autocheck:success', event => {
-          resolve(event.detail.warning)
+          resolve(event.detail.message)
         })
       }).then(result => {
         assert.equal('This is a warning', result)


### PR DESCRIPTION
Matches the error event behavior so both error and success contain an optional message payload. The application can decide to treat the message as a warning or informational as needed.