### PR TITLE
JSON and plain text support

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -17,8 +17,8 @@
     <h3>Form that handles JSON</h3>
     <form>
       <p>Input 422 for an error response.</p>
-      <auto-check csrf="foo" src="/json-demo">
-        <input autofocus class="json" name="foo">
+      <auto-check csrf="foo" src="/json-demo" required>
+        <input autofocus class="json" name="foo" required>
         <code class="state"></code>
       </auto-check>
       <button disabled>submit</button>

--- a/examples/index.html
+++ b/examples/index.html
@@ -39,6 +39,8 @@
         getResponseHeader(name) {
           if (name === 'Content-Type' && focusedInput.classList.contains('json')) {
             return 'application/json'
+          } else {
+            return 'plain/text'
           }
         }
         send() {

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,18 +4,28 @@
     <title>&lt;auto-check&gt; element</title>
   </head>
   <body>
+    <h3>Simple form</h3>
     <form>
       <p>Input 422 for an error response.</p>
       <auto-check csrf="foo" src="/demo">
         <input autofocus name="foo">
-        <code id="state"></code>
+        <code class="state"></code>
+      </auto-check>
+      <button disabled>submit</button>
+    </form>
+
+    <h3>Form that handles JSON</h3>
+    <form>
+      <p>Input 422 for an error response.</p>
+      <auto-check csrf="foo" src="/json-demo">
+        <input autofocus class="json" name="foo">
+        <code class="state"></code>
       </auto-check>
       <button disabled>submit</button>
     </form>
 
     <script>
-      const input = document.querySelector('input')
-      const button = document.querySelector('button')
+      let focusedInput
       class FakeXMLHttpRequest {
         abort() {
           // Do nothing.
@@ -26,28 +36,49 @@
         setRequestHeader(name, value) {
           // Do nothing.
         }
-        getResponseHeader(name, value) {
-          // Do nothing.
+        getResponseHeader(name) {
+          if (name === 'Content-Type' && focusedInput.classList.contains('json')) {
+            return 'application/json'
+          }
         }
         send() {
-          this.status = input.value === '422' ? 422 : 200
+          if (focusedInput.classList.contains('json')) {
+            this.responseText = '{"text": "success", "html": "<b>success</b>"}'
+          } else {
+            this.responseText = 'success'
+          }
+          this.status = focusedInput.value === '422' ? 422 : 200
           setTimeout(this.onload.bind(this), 0)
         }
       }
       window.XMLHttpRequest = FakeXMLHttpRequest
-      const state = document.getElementById('state')
-      document.addEventListener('auto-check-send', () => {
-        state.textContent = 'loading'
-        button.disabled = true
-      })
-      document.addEventListener('auto-check-success', () => {
-        state.textContent = 'success'
-        button.disabled = false
-      })
-      document.addEventListener('auto-check-error', () => {
-        state.textContent = 'error'
-        button.disabled = true
-      })
+
+      for (const form of document.querySelectorAll('form')) {
+        const formInput = form.querySelector('input')
+        const button = form.querySelector('button')
+        const state = form.querySelector('.state')
+
+        formInput.addEventListener('focus', () => {
+          focusedInput = formInput
+        })
+
+        form.addEventListener('auto-check-send', () => {
+          state.textContent = 'loading'
+          button.disabled = true
+        })
+        form.addEventListener('auto-check-success', event => {
+          if (focusedInput.classList.contains('json')) {
+            state.innerHTML = event.detail.message.html
+          } else {
+            state.textContent = event.detail.message
+          }
+          button.disabled = false
+        })
+        form.addEventListener('auto-check-error', () => {
+          state.textContent = 'error'
+          button.disabled = true
+        })
+      }
     </script>
 
     <script src="https://unpkg.com/@github/auto-check-element@latest/dist/index.umd.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,8 +7,8 @@
     <h1>Simple form</h1>
     <form>
       <p>Input 422 for an error response.</p>
-      <auto-check csrf="foo" src="/demo">
-        <input autofocus name="foo">
+      <auto-check csrf="foo" src="/demo" required>
+        <input autofocus name="foo" required>
         <code class="state"></code>
       </auto-check>
       <button disabled>submit</button>

--- a/examples/index.html
+++ b/examples/index.html
@@ -44,12 +44,14 @@
           }
         }
         send() {
-          if (focusedInput.classList.contains('json')) {
-            this.responseText = '{"text": "success", "html": "<b>success</b>"}'
+          const json = focusedInput.classList.contains('json')
+          if (focusedInput.value === '422') {
+            this.status = 422
+            this.responseText = json ? '{"text": "bad", "html": "<b>bad</b>"}' : 'bad'
           } else {
-            this.responseText = 'success'
+            this.status = 200
+            this.responseText = json ? '{"text": "success", "html": "<b>success</b>"}' : 'success'
           }
-          this.status = focusedInput.value === '422' ? 422 : 200
           setTimeout(this.onload.bind(this), 0)
         }
       }

--- a/examples/index.html
+++ b/examples/index.html
@@ -70,7 +70,7 @@
         })
         form.addEventListener('auto-check-success', event => {
           if (focusedInput.classList.contains('json')) {
-            state.innerHTML = event.detail.message.html
+            state.innerHTML = JSON.parse(event.detail.message).html
           } else {
             state.textContent = event.detail.message
           }

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,7 @@
     <title>&lt;auto-check&gt; element</title>
   </head>
   <body>
-    <h3>Simple form</h3>
+    <h1>Simple form</h1>
     <form>
       <p>Input 422 for an error response.</p>
       <auto-check csrf="foo" src="/demo">
@@ -14,7 +14,7 @@
       <button disabled>submit</button>
     </form>
 
-    <h3>Form that handles JSON</h3>
+    <h1>Form that handles JSON</h1>
     <form>
       <p>Input 422 for an error response.</p>
       <auto-check csrf="foo" src="/json-demo" required>

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ function check(autoCheckElement: AutoCheckElement) {
     .then(always, always)
 }
 
-function performCheck(input: HTMLInputElement, body: FormData, url: string): Promise<string | {text: string}> {
+function performCheck(input: HTMLInputElement, body: FormData, url: string): Promise<string> {
   const pending = requests.get(input)
   if (pending) pending.abort()
 
@@ -160,7 +160,7 @@ function performCheck(input: HTMLInputElement, body: FormData, url: string): Pro
   return result
 }
 
-function send(xhr: XMLHttpRequest, body: FormData): Promise<string | {text: string}> {
+function send(xhr: XMLHttpRequest, body: FormData): Promise<string> {
   return new Promise((resolve, reject) => {
     xhr.onload = function() {
       if (xhr.status >= 200 && xhr.status < 300) {

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ function check(autoCheckElement: AutoCheckElement) {
 
       if (error.statusCode === 422 && error.responseText) {
         if (error.contentType.includes('application/json')) {
-          validity = error.responseText.text
+          validity = JSON.parse(error.responseText).text
         } else {
           validity = error.responseText
         }
@@ -163,23 +163,14 @@ function performCheck(input: HTMLInputElement, body: FormData, url: string): Pro
 function send(xhr: XMLHttpRequest, body: FormData): Promise<string | {text: string}> {
   return new Promise((resolve, reject) => {
     xhr.onload = function() {
-      let data = xhr.responseText
-      if (xhr.getResponseHeader('Content-Type') === 'application/json') {
-        data = JSON.parse(data)
-      }
-
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve(data)
+        resolve(xhr.responseText)
       } else {
-        reject(new XHRError(xhr.status, data, xhr.getResponseHeader('Content-Type')))
+        reject(new XHRError(xhr.status, xhr.responseText, xhr.getResponseHeader('Content-Type')))
       }
     }
     xhr.onerror = function() {
-      let data = xhr.responseText
-      if (xhr.getResponseHeader('Content-Type') === 'application/json') {
-        data = JSON.parse(data)
-      }
-      reject(new XHRError(xhr.status, data, xhr.getResponseHeader('Content-Type')))
+      reject(new XHRError(xhr.status, xhr.responseText, xhr.getResponseHeader('Content-Type')))
     }
     xhr.send(body)
   })

--- a/src/index.js
+++ b/src/index.js
@@ -131,8 +131,7 @@ function check(autoCheckElement: AutoCheckElement) {
       if (error.statusCode === 422 && error.responseText) {
         if (error.contentType.includes('application/json')) {
           validity = error.responseText.text
-        }
-        if (error.contentType.includes('text/plain')) {
+        } else {
           validity = error.responseText
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,6 @@ function performCheck(input: HTMLInputElement, body: FormData, url: string): Pro
   requests.set(input, xhr)
 
   xhr.open('POST', url, true)
-  xhr.setRequestHeader('Accept', 'application/json, text/plain;q=0.9')
   const result = send(xhr, body)
   result.then(clear, clear)
   return result

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,12 +1,18 @@
 function checker(request, response, next) {
-  if (request.method === 'POST' && request.url.startsWith('/fail')) {
-    response.setHeader('Content-Type', 'text/html; fragment')
-    response.writeHead(422)
-    response.end('This is a error')
-    return
-  } else if (request.method === 'POST' && request.url.startsWith('/success')) {
+  if (request.method === 'POST' && request.url.startsWith('/plaintext')) {
+    response.setHeader('Content-Type', 'text/plain')
     response.writeHead(200)
     response.end('This is a warning')
+    return
+  } else if (request.method === 'POST' && request.url.startsWith('/fail')) {
+    response.setHeader('Content-Type', 'application/json')
+    response.writeHead(422)
+    response.end('{"text": "This is a error"}')
+    return
+  } else if (request.method === 'POST' && request.url.startsWith('/success')) {
+    response.setHeader('Content-Type', 'application/json')
+    response.writeHead(200)
+    response.end('{"text": "This is a warning"}')
     return
   }
   next()

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,6 +1,5 @@
 function checker(request, response, next) {
   if (request.method === 'POST' && request.url.startsWith('/plaintext')) {
-    response.setHeader('Content-Type', 'text/plain')
     response.writeHead(200)
     response.end('This is a warning')
     return

--- a/test/test.js
+++ b/test/test.js
@@ -67,18 +67,7 @@ describe('auto-check element', function() {
           resolve(event.detail.message)
         })
       }).then(result => {
-        assert.equal('This is a warning', result)
-      })
-    })
-
-    it('emits a error event when server returns a error response', function(done) {
-      const autoCheck = document.querySelector('auto-check')
-      const input = document.querySelector('input')
-      autoCheck.src = '/fail'
-      input.value = 'hub'
-      input.dispatchEvent(new InputEvent('change'))
-      input.addEventListener('auto-check-error', () => {
-        done()
+        assert.deepEqual({text: 'This is a warning'}, result)
       })
     })
 
@@ -93,7 +82,7 @@ describe('auto-check element', function() {
           resolve(event.detail.message)
         })
       }).then(result => {
-        assert.equal('This is a error', result)
+        assert.deepEqual({text: 'This is a error'}, result)
       })
     })
 
@@ -175,6 +164,21 @@ describe('auto-check element', function() {
       input.value = 'hub'
       input.dispatchEvent(new InputEvent('change'))
       input.dispatchEvent(new InputEvent('change'))
+    })
+
+    it('handles plain text responses', function() {
+      return new Promise(resolve => {
+        const autoCheck = document.querySelector('auto-check')
+        const input = document.querySelector('input')
+        autoCheck.src = '/plaintext'
+        input.value = 'hub'
+        input.dispatchEvent(new InputEvent('change'))
+        input.addEventListener('auto-check-success', event => {
+          resolve(event.detail.message)
+        })
+      }).then(result => {
+        assert.deepEqual('This is a warning', result)
+      })
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -67,7 +67,7 @@ describe('auto-check element', function() {
           resolve(event.detail.message)
         })
       }).then(result => {
-        assert.deepEqual({text: 'This is a warning'}, result)
+        assert.deepEqual('{"text": "This is a warning"}', result)
       })
     })
 
@@ -82,7 +82,7 @@ describe('auto-check element', function() {
           resolve(event.detail.message)
         })
       }).then(result => {
-        assert.deepEqual({text: 'This is a error'}, result)
+        assert.deepEqual('{"text": "This is a error"}', result)
       })
     })
 


### PR DESCRIPTION
Accept JSON as a response as well as plain text for simple checks.

When sending JSON the `text` field is required so that we can set the validity of the element but then the application can send any data as a response. The returned response will be returned via the success or error events.

This means that we'll always set the custom validity with the correct message without HTML but preserve the ability to set HTML notes on error in the application using the element.

Also updated karma.

Ref: #17 