### PR TITLE
Only dispatch event with json/text payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -127,11 +127,14 @@ function check(autoCheckElement: AutoCheckElement) {
     })
     .catch(error => {
       let validity = 'Something went wrong'
+      let message = error.responseText
 
-      if (error.statusCode === 422 && error.responseText) {
+      if (!(error.contentType.includes('application/json') || error.contentType.includes('text/plain'))) {
+        message = 'Something went wrong'
+      } else if (error.statusCode === 422 && error.responseText) {
         if (error.contentType.includes('application/json')) {
           validity = JSON.parse(error.responseText).text
-        } else {
+        } else if (error.contentType.includes('text/plain')) {
           validity = error.responseText
         }
       }
@@ -140,7 +143,7 @@ function check(autoCheckElement: AutoCheckElement) {
         input.setCustomValidity(validity)
       }
       autoCheckElement.dispatchEvent(new CustomEvent('error'))
-      input.dispatchEvent(new CustomEvent('auto-check-error', {detail: {message: error.responseText}, bubbles: true}))
+      input.dispatchEvent(new CustomEvent('auto-check-error', {detail: {message}, bubbles: true}))
     })
     .then(always, always)
 }

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -13,6 +13,12 @@ function checker(request, response, next) {
     response.writeHead(200)
     response.end('{"text": "This is a warning"}')
     return
+  } else if (request.method === 'POST' && request.url.startsWith('/error')) {
+    response.setHeader('Content-Type', 'text/html')
+    response.writeHead(422)
+    // eslint-disable-next-line github/unescaped-html-literal
+    response.end('<strong>Wrong parameters</strong>')
+    return
   }
   next()
 }

--- a/test/test.js
+++ b/test/test.js
@@ -180,5 +180,20 @@ describe('auto-check element', function() {
         assert.deepEqual('This is a warning', result)
       })
     })
+
+    it("doesn't emit events with HTML payload", function() {
+      return new Promise(resolve => {
+        const autoCheck = document.querySelector('auto-check')
+        const input = document.querySelector('input')
+        autoCheck.src = '/error'
+        input.value = 'hub'
+        input.dispatchEvent(new InputEvent('change'))
+        input.addEventListener('auto-check-error', event => {
+          resolve(event.detail.message)
+        })
+      }).then(result => {
+        assert.deepEqual('Something went wrong', result)
+      })
+    })
   })
 })


### PR DESCRIPTION
The reason why we only used responses with `Content-Type: text/html; fragment` in the past is because rails would return HTML errors when something was wrong and the `<auto-check>` component would happily cram it into the warning note.

We regressed this behavior in #18. This PR bring back a similar behavior by only dispatching an error event payload if it's JSON or text.

Ref: https://github.com/github/github/pull/87161#issue-176439296