### PR TITLE
Set content type in error event payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ function check(autoCheckElement: AutoCheckElement) {
       if (error.statusCode === 422 && error.responseText) {
         if (error.contentType.includes('application/json')) {
           validity = JSON.parse(error.responseText).text
-        } else {
+        } else if (error.contentType.includes('text/plain')) {
           validity = error.responseText
         }
       }
@@ -140,7 +140,12 @@ function check(autoCheckElement: AutoCheckElement) {
         input.setCustomValidity(validity)
       }
       autoCheckElement.dispatchEvent(new CustomEvent('error'))
-      input.dispatchEvent(new CustomEvent('auto-check-error', {detail: {message: error.responseText}, bubbles: true}))
+      input.dispatchEvent(
+        new CustomEvent('auto-check-error', {
+          detail: {message: error.responseText, contentType: error.contentType},
+          bubbles: true
+        })
+      )
     })
     .then(always, always)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -180,5 +180,22 @@ describe('auto-check element', function() {
         assert.deepEqual('This is a warning', result)
       })
     })
+
+    describe('`auto-check-error` event', function() {
+      it('includes `Content-Type` header in event payload', function() {
+        return new Promise(resolve => {
+          const autoCheck = document.querySelector('auto-check')
+          const input = document.querySelector('input')
+          autoCheck.src = '/fail'
+          input.value = 'hub'
+          input.dispatchEvent(new InputEvent('change'))
+          input.addEventListener('auto-check-error', event => {
+            resolve(event.detail.contentType)
+          })
+        }).then(contentType => {
+          assert.equal('application/json', contentType)
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Add the `Content-Type` header to the `auto-check-error` event payload so that the application can decide what to do based on the type of response it received from the server.

Closes #23 