### PR TITLE
Add TS window declaration for AutoCheckElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,3 +4,9 @@ export default class AutoCheckElement extends HTMLElement {
   csrf: string;
   required: boolean;
 }
+
+declare global {
+  interface Window {
+    AutoCheckElement: typeof AutoCheckElement
+  }
+}


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignment to Window.

This PR adds the declaration of `AutoCheckElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58