### PR TITLE
Add response to event payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,8 +147,15 @@ async function check(autoCheckElement: AutoCheckElement) {
     if (autoCheckElement.required) {
       input.setCustomValidity('Input is not valid')
     }
-    autoCheckElement.dispatchEvent(new CustomEvent('error'))
-    input.dispatchEvent(new CustomEvent('auto-check-error', {detail: {response: response.clone()}, bubbles: true}))
+
+    // Dispatch validation error event if there is a validation error,
+    // otherwise dispatch a normal error event.
+    if (response.status === 422) {
+      input.dispatchEvent(new CustomEvent('auto-check-error', {detail: {response: response.clone()}, bubbles: true}))
+    } else {
+      autoCheckElement.dispatchEvent(new CustomEvent('error'))
+    }
+
     // Mark the component as not being in-flight any more.
     abortControllers.delete(autoCheckElement)
 

--- a/src/index.js
+++ b/src/index.js
@@ -151,31 +151,25 @@ function check(autoCheckElement: AutoCheckElement) {
       if (response.status !== 200) {
         throw new ErrorWithResponse(response.statusText, response)
       }
-      return response.text()
+      return response
     })
-    .then(message => {
+    .then(response => {
       autoCheckElement.dispatchEvent(new CustomEvent('load'))
       if (autoCheckElement.required) {
         input.setCustomValidity('')
       }
-      input.dispatchEvent(new CustomEvent('auto-check-success', {detail: {message}, bubbles: true}))
+      input.dispatchEvent(new CustomEvent('auto-check-success', {detail: {response: response.clone()}, bubbles: true}))
 
       // Mark the component as not being in-flight any more.
       abortControllers.delete(autoCheckElement)
     })
-    .catch(async error => {
-      const message = await error.response.text()
-      const contentType = error.response.headers.get('Content-Type')
-
+    .catch(error => {
       if (autoCheckElement.required) {
         input.setCustomValidity('Input is not valid')
       }
       autoCheckElement.dispatchEvent(new CustomEvent('error'))
       input.dispatchEvent(
-        new CustomEvent('auto-check-error', {
-          detail: {message, contentType},
-          bubbles: true
-        })
+        new CustomEvent('auto-check-error', {detail: {response: error.response.clone()}, bubbles: true})
       )
       // Mark the component as not being in-flight any more.
       abortControllers.delete(autoCheckElement)

--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,7 @@ async function check(autoCheckElement: AutoCheckElement) {
     if (!response) {
       throw error
     }
+
     if (autoCheckElement.required) {
       input.setCustomValidity('Input is not valid')
     }
@@ -159,19 +160,22 @@ async function check(autoCheckElement: AutoCheckElement) {
     // Mark the component as not being in-flight any more.
     abortControllers.delete(autoCheckElement)
 
+    // Dispatch end of lifetime events
     autoCheckElement.dispatchEvent(new CustomEvent('loadend'))
     input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
     return
   }
 
-  autoCheckElement.dispatchEvent(new CustomEvent('load'))
   if (autoCheckElement.required) {
     input.setCustomValidity('')
   }
+  autoCheckElement.dispatchEvent(new CustomEvent('load'))
   input.dispatchEvent(new CustomEvent('auto-check-success', {detail: {response: response.clone()}, bubbles: true}))
 
   // Mark the component as not being in-flight any more.
   abortControllers.delete(autoCheckElement)
+
+  // Dispatch end of lifetime events
   autoCheckElement.dispatchEvent(new CustomEvent('loadend'))
   input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
 }

--- a/test/test.js
+++ b/test/test.js
@@ -63,8 +63,9 @@ describe('auto-check element', function() {
         const input = document.querySelector('input')
         input.value = 'hub'
         input.dispatchEvent(new InputEvent('change'))
-        input.addEventListener('auto-check-success', event => {
-          resolve(event.detail.message)
+        input.addEventListener('auto-check-success', async event => {
+          const message = await event.detail.response.text()
+          resolve(message)
         })
       }).then(result => {
         assert.deepEqual('{"text": "This is a warning"}', result)
@@ -78,8 +79,9 @@ describe('auto-check element', function() {
         autoCheck.src = '/fail'
         input.value = 'hub'
         input.dispatchEvent(new InputEvent('change'))
-        input.addEventListener('auto-check-error', () => {
-          resolve(event.detail.message)
+        input.addEventListener('auto-check-error', async event => {
+          const message = await event.detail.response.text()
+          resolve(message)
         })
       }).then(result => {
         assert.deepEqual('{"text": "This is a error"}', result)
@@ -173,8 +175,9 @@ describe('auto-check element', function() {
         autoCheck.src = '/plaintext'
         input.value = 'hub'
         input.dispatchEvent(new InputEvent('change'))
-        input.addEventListener('auto-check-success', event => {
-          resolve(event.detail.message)
+        input.addEventListener('auto-check-success', async event => {
+          const message = await event.detail.response.text()
+          resolve(message)
         })
       }).then(result => {
         assert.deepEqual('This is a warning', result)
@@ -189,8 +192,9 @@ describe('auto-check element', function() {
           autoCheck.src = '/fail'
           input.value = 'hub'
           input.dispatchEvent(new InputEvent('change'))
-          input.addEventListener('auto-check-error', event => {
-            resolve(event.detail.contentType)
+          input.addEventListener('auto-check-error', async event => {
+            const contentType = await event.detail.response.headers.get('Content-Type')
+            resolve(contentType)
           })
         }).then(contentType => {
           assert.equal('application/json', contentType)


### PR DESCRIPTION
This PR breaks the API by setting the `auto-check-success` and `auto-check-error` to `{response: Response}` instead of `{message: string}` and `{message: string, contentType: string}` respectively.

This means that the application is responsible from reading the response body and/or anything else it needs such as status or headers. Having a [standardized and documented object](https://developer.mozilla.org/en-US/docs/Web/API/Response) that the application can operate on means that we don't need to specifically document it.