### PR TITLE
Use AbortController to cancel old requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,12 +166,12 @@ async function check(autoCheckElement: AutoCheckElement) {
       input.dispatchEvent(new CustomEvent('auto-check-error', {detail: {response: response.clone()}, bubbles: true}))
     }
     state.controller = null
+    input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
   } catch (error) {
     if (error.name !== 'AbortError') {
       state.controller = null
+      input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
     }
-  } finally {
-    input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -165,11 +165,11 @@ async function check(autoCheckElement: AutoCheckElement) {
     return
   }
 
-  try {
-    if (autoCheckElement.required) {
-      input.setCustomValidity('Verifying…')
-    }
+  if (autoCheckElement.required) {
+    input.setCustomValidity('Verifying…')
+  }
 
+  try {
     const response = await slidingPromiseFetch(autoCheckElement, src, {body, method: 'POST'})
     if (response.status === 200) {
       if (autoCheckElement.required) {

--- a/src/index.js
+++ b/src/index.js
@@ -165,10 +165,12 @@ async function check(autoCheckElement: AutoCheckElement) {
       }
       input.dispatchEvent(new CustomEvent('auto-check-error', {detail: {response: response.clone()}, bubbles: true}))
     }
-  } catch (error) {
-    // Network and abort errors handled already.
-  } finally {
     state.controller = null
+  } catch (error) {
+    if (error.name !== 'AbortError') {
+      state.controller = null
+    }
+  } finally {
     input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,23 +12,16 @@ const states = new WeakMap<AutoCheckElement, State>()
 const requests = new WeakMap()
 
 export default class AutoCheckElement extends HTMLElement {
-  constructor() {
-    super()
-    states.set(this, {
-      check: debounce(check.bind(null, this), 300),
-      request: null
-    })
-  }
-
   connectedCallback() {
     const input = this.input
     if (!input) return
 
-    const state = states.get(this)
-    if (!state) return
+    const checker = debounce(check.bind(null, this), 300)
+    const state = {check: checker, request: null}
+    states.set(this, state)
 
-    input.addEventListener('change', state.check)
-    input.addEventListener('input', state.check)
+    input.addEventListener('change', checker)
+    input.addEventListener('input', checker)
     input.autocomplete = 'off'
     input.spellcheck = false
   }
@@ -39,6 +32,7 @@ export default class AutoCheckElement extends HTMLElement {
 
     const state = states.get(this)
     if (!state) return
+    states.delete(this)
 
     input.removeEventListener('change', state.check)
     input.removeEventListener('input', state.check)

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ function makeAbortController() {
 
 async function slidingPromiseFetch(el: HTMLElement, url: string, options: RequestOptions = {}): Promise<Response> {
   let request = requests.get(el)
-  const [promise, resolve, reject] = makeDeferred<Response>()
+  const [promise, resolve, reject] = makeDeferred()
 
   if (request) {
     request.controller.abort()

--- a/src/index.js
+++ b/src/index.js
@@ -2,25 +2,33 @@
 
 import debounce from './debounce'
 
+type State = {
+  check: Event => mixed,
+  request: ?Request
+}
+
 const previousValues = new WeakMap()
-const checkFunctions = new WeakMap<AutoCheckElement, (Event) => mixed>()
+const states = new WeakMap<AutoCheckElement, State>()
 const requests = new WeakMap()
 
 export default class AutoCheckElement extends HTMLElement {
   constructor() {
     super()
-    checkFunctions.set(this, debounce(check.bind(null, this), 300))
+    states.set(this, {
+      check: debounce(check.bind(null, this), 300),
+      request: null
+    })
   }
 
   connectedCallback() {
     const input = this.input
     if (!input) return
 
-    const checkFunction = checkFunctions.get(this)
-    if (!checkFunction) return
+    const state = states.get(this)
+    if (!state) return
 
-    input.addEventListener('change', checkFunction)
-    input.addEventListener('input', checkFunction)
+    input.addEventListener('change', state.check)
+    input.addEventListener('input', state.check)
     input.autocomplete = 'off'
     input.spellcheck = false
   }
@@ -29,11 +37,11 @@ export default class AutoCheckElement extends HTMLElement {
     const input = this.input
     if (!input) return
 
-    const checkFunction = checkFunctions.get(this)
-    if (!checkFunction) return
+    const state = states.get(this)
+    if (!state) return
 
-    input.removeEventListener('change', checkFunction)
-    input.removeEventListener('input', checkFunction)
+    input.removeEventListener('change', state.check)
+    input.removeEventListener('input', state.check)
     input.setCustomValidity('')
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -183,7 +183,7 @@ async function check(autoCheckElement: AutoCheckElement) {
       input.dispatchEvent(new CustomEvent('auto-check-error', {detail: {response: response.clone()}, bubbles: true}))
     }
   } catch (error) {
-    // We've caught the network error here but don't need to handle it since the `performCheck` function has dispatched the events needed.
+    // We've caught the network error here but don't need to handle it since the `slidingPromiseFetch` function has dispatched the events needed.
   } finally {
     input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
   }

--- a/test/test.js
+++ b/test/test.js
@@ -63,8 +63,8 @@ describe('auto-check element', function() {
         const input = document.querySelector('input')
         input.value = 'hub'
         input.dispatchEvent(new InputEvent('change'))
-        input.addEventListener('auto-check-success', event => {
-          resolve(event.detail.message)
+        input.addEventListener('auto-check-success', async event => {
+          resolve(await event.detail.response.text())
         })
       }).then(result => {
         assert.deepEqual('{"text": "This is a warning"}', result)
@@ -78,8 +78,8 @@ describe('auto-check element', function() {
         autoCheck.src = '/fail'
         input.value = 'hub'
         input.dispatchEvent(new InputEvent('change'))
-        input.addEventListener('auto-check-error', () => {
-          resolve(event.detail.message)
+        input.addEventListener('auto-check-error', async () => {
+          resolve(await event.detail.response.text())
         })
       }).then(result => {
         assert.deepEqual('{"text": "This is a error"}', result)
@@ -173,8 +173,8 @@ describe('auto-check element', function() {
         autoCheck.src = '/plaintext'
         input.value = 'hub'
         input.dispatchEvent(new InputEvent('change'))
-        input.addEventListener('auto-check-success', event => {
-          resolve(event.detail.message)
+        input.addEventListener('auto-check-success', async event => {
+          resolve(await event.detail.response.text())
         })
       }).then(result => {
         assert.deepEqual('This is a warning', result)
@@ -190,7 +190,7 @@ describe('auto-check element', function() {
           input.value = 'hub'
           input.dispatchEvent(new InputEvent('change'))
           input.addEventListener('auto-check-error', event => {
-            resolve(event.detail.contentType)
+            resolve(event.detail.response.headers.get('Content-Type'))
           })
         }).then(contentType => {
           assert.equal('application/json', contentType)


### PR DESCRIPTION
Me and @dgraham worked on this but ran out of time and I filled in the rest by my own. I'd be interested in hearing what you think about those changes I did to be able to raise this PR.

This PR does a few things:

- We don't dispatch error events when the error is a `AbortError` since we were the ones that aborted it and we have started a new request.
- Breaking change: We add the whole `Response` in the success event payload instead of just the response body and the content type. The application can operate however they want on the whole Response.
- Refactor so that the network events (`load`, `loadstart`, `loaden` and `error`) are dispatched at correct places.
- Refactor so that we can remove `ErrorWithResponse`.

Closes: #30
Closes: #31