### PR TITLE
Set input as invalid on input before debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,31 @@ check.addEventListener('error', function(event) {
 
 ### Auto-check events
 
-**`auto-check-send`** is dispatched before the network request begins. In `event.detail` you can find:
+**`auto-check-input`** is dispatched on when there has been input in the element. In `event.detail` you can find:
 
-- `body`: The FormData request body to modify before the request is sent.
-- `setValidity`: A function to provide a custom validation message while the request is in-flight. By default it is 'Verifying…'.
+- `setValidity`: A function to provide a custom failure message on the input. By default it is 'Verifying…'.
 
 
 ```js
 const input = check.querySelector('input')
 
 input.addEventListener('auto-check-send', function(event) {
-  const {body, setValidity} = event.detail
+  const {setValidity} = event.detail
+  setValidity('Loading validation')
+})
+```
+
+**`auto-check-send`** is dispatched before the network request begins. In `event.detail` you can find:
+
+- `body`: The FormData request body to modify before the request is sent.
+
+
+```js
+const input = check.querySelector('input')
+
+input.addEventListener('auto-check-send', function(event) {
+  const {body} = event.detail
   body.append('custom_form_data', 'value')
-  setValidity('Checking with server…')
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ check.addEventListener('error', function(event) {
 
 ### Auto-check events
 
-**`auto-check-input`** is dispatched on when there has been input in the element. In `event.detail` you can find:
+**`auto-check-start`** is dispatched on when there has been input in the element. In `event.detail` you can find:
 
 - `setValidity`: A function to provide a custom failure message on the input. By default it is 'Verifying…'.
 
@@ -57,7 +57,7 @@ check.addEventListener('error', function(event) {
 ```js
 const input = check.querySelector('input')
 
-input.addEventListener('auto-check-input', function(event) {
+input.addEventListener('auto-check-start', function(event) {
   const {setValidity} = event.detail
   setValidity('Loading validation')
 })

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ check.addEventListener('error', function(event) {
 ```js
 const input = check.querySelector('input')
 
-input.addEventListener('auto-check-send', function(event) {
+input.addEventListener('auto-check-input', function(event) {
   const {setValidity} = event.detail
   setValidity('Loading validation')
 })

--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,7 @@ async function check(autoCheckElement: AutoCheckElement) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
     }
+    input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
     return
   }
 
@@ -158,7 +159,10 @@ async function check(autoCheckElement: AutoCheckElement) {
   body.append('value', input.value)
 
   const id = body.entries ? [...body.entries()].sort().toString() : null
-  if (id && id === state.previousValue) return
+  if (id && id === state.previousValue) {
+    input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
+    return
+  }
   state.previousValue = id
 
   input.dispatchEvent(

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,6 @@ async function check(autoCheckElement: AutoCheckElement) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
     }
-    input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
     return
   }
 
@@ -160,17 +159,13 @@ async function check(autoCheckElement: AutoCheckElement) {
   body.append('value', input.value)
 
   const id = body.entries ? [...body.entries()].sort().toString() : null
-  if (id && id === state.previousValue) {
-    input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
-    return
-  }
+  if (id && id === state.previousValue) return
   state.previousValue = id
 
   if (!input.value.trim()) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
     }
-    input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
     return
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ function setLoadingState(event: Event) {
   let message = 'Verifying…'
   const setValidity = text => (message = text)
   input.dispatchEvent(
-    new CustomEvent('auto-check-input', {
+    new CustomEvent('auto-check-start', {
       bubbles: true,
       detail: {setValidity}
     })

--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,7 @@ async function check(autoCheckElement: AutoCheckElement) {
   const csrf = autoCheckElement.csrf
   const state = states.get(autoCheckElement)
 
+  // If some attributes are missing we want to exit early and make sure that the element is valid.
   if (!src || !csrf || !state) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,18 @@ function setLoadingState(event: Event) {
   const input = event.currentTarget
   if (!(input instanceof HTMLInputElement)) return
 
+  const autoCheckElement = input.closest('auto-check')
+  if (!(autoCheckElement instanceof AutoCheckElement)) return
+
+  const src = autoCheckElement.src
+  const csrf = autoCheckElement.csrf
+  const state = states.get(autoCheckElement)
+
+  // If some attributes are missing we want to exit early and make sure that the element is valid.
+  if (!src || !csrf || !state) {
+    return
+  }
+
   let message = 'Verifying…'
   const setValidity = text => (message = text)
   input.dispatchEvent(
@@ -108,8 +120,7 @@ function setLoadingState(event: Event) {
     })
   )
 
-  const autoCheckElement = input.closest('auto-check')
-  if (autoCheckElement instanceof AutoCheckElement && autoCheckElement.required) {
+  if (autoCheckElement.required) {
     input.setCustomValidity(message)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -99,9 +99,18 @@ function setLoadingState(event: Event) {
   const input = event.currentTarget
   if (!(input instanceof HTMLInputElement)) return
 
+  let message = 'Verifying…'
+  const setValidity = text => (message = text)
+  input.dispatchEvent(
+    new CustomEvent('auto-check-loading', {
+      bubbles: true,
+      detail: {setValidity}
+    })
+  )
+
   const autoCheckElement = input.closest('auto-check')
   if (autoCheckElement instanceof AutoCheckElement && autoCheckElement.required) {
-    input.setCustomValidity('Verifying…')
+    input.setCustomValidity(message)
   }
 }
 
@@ -152,12 +161,10 @@ async function check(autoCheckElement: AutoCheckElement) {
   if (id && id === state.previousValue) return
   state.previousValue = id
 
-  let message = 'Verifying…'
-  const setValidity = text => (message = text)
   input.dispatchEvent(
     new CustomEvent('auto-check-send', {
       bubbles: true,
-      detail: {body, setValidity}
+      detail: {body}
     })
   )
 
@@ -167,10 +174,6 @@ async function check(autoCheckElement: AutoCheckElement) {
     }
     input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
     return
-  }
-
-  if (autoCheckElement.required) {
-    input.setCustomValidity(message)
   }
 
   if (state.controller) {

--- a/src/index.js
+++ b/src/index.js
@@ -166,13 +166,6 @@ async function check(autoCheckElement: AutoCheckElement) {
   }
   state.previousValue = id
 
-  input.dispatchEvent(
-    new CustomEvent('auto-check-send', {
-      bubbles: true,
-      detail: {body}
-    })
-  )
-
   if (!input.value.trim()) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
@@ -180,6 +173,13 @@ async function check(autoCheckElement: AutoCheckElement) {
     input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
     return
   }
+
+  input.dispatchEvent(
+    new CustomEvent('auto-check-send', {
+      bubbles: true,
+      detail: {body}
+    })
+  )
 
   if (state.controller) {
     state.controller.abort()

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ function setLoadingState(event: Event) {
   let message = 'Verifying…'
   const setValidity = text => (message = text)
   input.dispatchEvent(
-    new CustomEvent('auto-check-loading', {
+    new CustomEvent('auto-check-input', {
       bubbles: true,
       detail: {setValidity}
     })

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,24 @@ describe('auto-check element', function() {
       assert.isFalse(input.checkValidity())
     })
 
+    it('validates the input element if there is no `src` attribute', async function() {
+      checker.removeAttribute('src')
+      const completeEvent = once(checker, 'auto-check-complete')
+      triggerChange(input, 'hub')
+      await completeEvent
+      assert.isTrue(input.checkValidity())
+      checker.src = '/success'
+    })
+
+    it('validates the input element if there is no `csrf` attribute', async function() {
+      checker.removeAttribute('csrf')
+      const completeEvent = once(checker, 'auto-check-complete')
+      triggerChange(input, 'hub')
+      await completeEvent
+      assert.isTrue(input.checkValidity())
+      checker.csrf = 'foo'
+    })
+
     it('invalidates input request is in-flight', async function() {
       triggerChange(input, 'hub')
       await once(checker, 'loadstart')

--- a/test/test.js
+++ b/test/test.js
@@ -51,24 +51,6 @@ describe('auto-check element', function() {
       assert.isFalse(input.checkValidity())
     })
 
-    it('validates the input element if there is no `src` attribute', async function() {
-      checker.removeAttribute('src')
-      const completeEvent = once(checker, 'auto-check-complete')
-      triggerChange(input, 'hub')
-      await completeEvent
-      assert.isTrue(input.checkValidity())
-      checker.src = '/success'
-    })
-
-    it('validates the input element if there is no `csrf` attribute', async function() {
-      checker.removeAttribute('csrf')
-      const completeEvent = once(checker, 'auto-check-complete')
-      triggerChange(input, 'hub')
-      await completeEvent
-      assert.isTrue(input.checkValidity())
-      checker.csrf = 'foo'
-    })
-
     it('invalidates input request is in-flight', async function() {
       triggerChange(input, 'hub')
       await once(checker, 'loadstart')

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,13 @@ describe('auto-check element', function() {
       assert.isFalse(input.checkValidity())
     })
 
+    it('invalidates input on keypress', async function() {
+      const inputEvent = once(input, 'change')
+      triggerChange(input, 'hub')
+      await inputEvent
+      assert.isFalse(input.checkValidity())
+    })
+
     it('invalidates input request is in-flight', async function() {
       triggerChange(input, 'hub')
       await once(checker, 'loadstart')

--- a/test/test.js
+++ b/test/test.js
@@ -170,6 +170,17 @@ describe('auto-check element', function() {
       input = null
     })
 
+    it('emits auto-check-send on input', function(done) {
+      input.addEventListener('auto-check-send', () => done())
+      input.value = 'hub'
+      input.dispatchEvent(new InputEvent('input'))
+    })
+
+    it('emits auto-check-send on change', function(done) {
+      input.addEventListener('auto-check-send', () => done())
+      triggerChange(input, 'hub')
+    })
+
     it('emits auto-check-input on input', function(done) {
       input.addEventListener('auto-check-input', () => done())
       input.value = 'hub'
@@ -179,6 +190,12 @@ describe('auto-check element', function() {
     it('emits auto-check-input on change', function(done) {
       input.addEventListener('auto-check-input', () => done())
       triggerChange(input, 'hub')
+    })
+
+    it('emits auto-check-send 300 milliseconds after keypress', function(done) {
+      input.addEventListener('auto-check-send', () => done())
+      input.value = 'hub'
+      input.dispatchEvent(new InputEvent('input'))
     })
 
     it('emits auto-check-success when server responds with 200 OK', async function() {
@@ -201,9 +218,9 @@ describe('auto-check element', function() {
       triggerChange(input, 'hub')
     })
 
-    it('emits auto-check-input event before checking if there is a duplicate request', function(done) {
+    it('emits auto-check-send event before checking if there is a duplicate request', function(done) {
       let counter = 2
-      input.addEventListener('auto-check-input', () => {
+      input.addEventListener('auto-check-send', () => {
         if (counter === 2) {
           done()
         } else {

--- a/test/test.js
+++ b/test/test.js
@@ -232,6 +232,14 @@ describe('auto-check element', function() {
       input.dispatchEvent(new InputEvent('change'))
       input.dispatchEvent(new InputEvent('change'))
     })
+
+    it('do not emit if essential attributes are missing', async function() {
+      const events = []
+      checker.removeAttribute('src')
+      input.addEventListener('auto-check-start', event => events.push(event.type))
+      triggerChange(input, 'hub')
+      assert.deepEqual(events, [])
+    })
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -44,7 +44,7 @@ describe('auto-check element', function() {
       assert.isFalse(input.checkValidity())
     })
 
-    it('invalidates input on keypress', async function() {
+    it('invalidates the input element on keypress', async function() {
       const inputEvent = once(input, 'change')
       triggerChange(input, 'hub')
       await inputEvent

--- a/test/test.js
+++ b/test/test.js
@@ -73,7 +73,7 @@ describe('auto-check element', function() {
     it('customizes the in-flight message', async function() {
       checker.src = '/fail'
       const send = new Promise(resolve => {
-        input.addEventListener('auto-check-loading', event => {
+        input.addEventListener('auto-check-input', event => {
           event.detail.setValidity('Checking with server')
           resolve()
         })
@@ -170,14 +170,14 @@ describe('auto-check element', function() {
       input = null
     })
 
-    it('emits auto-check-loading on input', function(done) {
-      input.addEventListener('auto-check-loading', () => done())
+    it('emits auto-check-input on input', function(done) {
+      input.addEventListener('auto-check-input', () => done())
       input.value = 'hub'
       input.dispatchEvent(new InputEvent('input'))
     })
 
-    it('emits auto-check-loading on change', function(done) {
-      input.addEventListener('auto-check-loading', () => done())
+    it('emits auto-check-input on change', function(done) {
+      input.addEventListener('auto-check-input', () => done())
       triggerChange(input, 'hub')
     })
 
@@ -201,9 +201,9 @@ describe('auto-check element', function() {
       triggerChange(input, 'hub')
     })
 
-    it('emits auto-check-loading event before checking if there is a duplicate request', function(done) {
+    it('emits auto-check-input event before checking if there is a duplicate request', function(done) {
       let counter = 2
-      input.addEventListener('auto-check-loading', () => {
+      input.addEventListener('auto-check-input', () => {
         if (counter === 2) {
           done()
         } else {

--- a/test/test.js
+++ b/test/test.js
@@ -73,7 +73,7 @@ describe('auto-check element', function() {
     it('customizes the in-flight message', async function() {
       checker.src = '/fail'
       const send = new Promise(resolve => {
-        input.addEventListener('auto-check-send', event => {
+        input.addEventListener('auto-check-loading', event => {
           event.detail.setValidity('Checking with server')
           resolve()
         })
@@ -170,14 +170,14 @@ describe('auto-check element', function() {
       input = null
     })
 
-    it('emits auto-check-send on input', function(done) {
-      input.addEventListener('auto-check-send', () => done())
+    it('emits auto-check-loading on input', function(done) {
+      input.addEventListener('auto-check-loading', () => done())
       input.value = 'hub'
       input.dispatchEvent(new InputEvent('input'))
     })
 
-    it('emits auto-check-send on change', function(done) {
-      input.addEventListener('auto-check-send', () => done())
+    it('emits auto-check-loading on change', function(done) {
+      input.addEventListener('auto-check-loading', () => done())
       triggerChange(input, 'hub')
     })
 
@@ -201,9 +201,9 @@ describe('auto-check element', function() {
       triggerChange(input, 'hub')
     })
 
-    it('emits auto-check-send event before checking if there is a duplicate request', function(done) {
+    it('emits auto-check-loading event before checking if there is a duplicate request', function(done) {
       let counter = 2
-      input.addEventListener('auto-check-send', () => {
+      input.addEventListener('auto-check-loading', () => {
         if (counter === 2) {
           done()
         } else {

--- a/test/test.js
+++ b/test/test.js
@@ -73,7 +73,7 @@ describe('auto-check element', function() {
     it('customizes the in-flight message', async function() {
       checker.src = '/fail'
       const send = new Promise(resolve => {
-        input.addEventListener('auto-check-input', event => {
+        input.addEventListener('auto-check-start', event => {
           event.detail.setValidity('Checking with server')
           resolve()
         })
@@ -181,14 +181,14 @@ describe('auto-check element', function() {
       triggerChange(input, 'hub')
     })
 
-    it('emits auto-check-input on input', function(done) {
-      input.addEventListener('auto-check-input', () => done())
+    it('emits auto-check-start on input', function(done) {
+      input.addEventListener('auto-check-start', () => done())
       input.value = 'hub'
       input.dispatchEvent(new InputEvent('input'))
     })
 
-    it('emits auto-check-input on change', function(done) {
-      input.addEventListener('auto-check-input', () => done())
+    it('emits auto-check-start on change', function(done) {
+      input.addEventListener('auto-check-start', () => done())
       triggerChange(input, 'hub')
     })
 


### PR DESCRIPTION
Before this change we would make the element invalid while a request was being made. This was happening inside the debounced function. Which means that in the 300ms from triggering a input event a user could submit a form with the input as being valid even though it hadn't been validated yet.

This change moves the functionality that makes the input invalid while loading outside the debounced function so that this isn't possible anymore.

Ref: https://github.com/github/github/issues/125112