### PR TITLE
Specify same-origin credentials

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,7 @@ async function check(autoCheckElement: AutoCheckElement) {
 
   try {
     const response = await fetchWithNetworkEvents(autoCheckElement, src, {
+      credentials: 'same-origin',
       signal: state.controller.signal,
       method: 'POST',
       body


### PR DESCRIPTION
This is the [default value](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials), but older fetch implementations use the previous default of `omit`.