### PR TITLE
missing @ in flow declaration

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,4 +1,4 @@
-/* flow strict */
+/* @flow strict */
 
 declare module 'auto-check-element' {
   declare export default class AutoCheckElement extends HTMLElement {


### PR DESCRIPTION
😭 

This causes apps importing trying to import the element to fail with a flow untyped module exception.