### PR TITLE
Move nulling of controller before processing response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,12 +194,12 @@ async function check(autoCheckElement: AutoCheckElement) {
       method: 'POST',
       body
     })
+    state.controller = null
     if (response.status === 200) {
       processSuccess(response, input, autoCheckElement.required)
     } else {
       processFailure(response, input, autoCheckElement.required)
     }
-    state.controller = null
     input.dispatchEvent(new CustomEvent('auto-check-complete', {bubbles: true}))
   } catch (error) {
     if (error.name !== 'AbortError') {


### PR DESCRIPTION
In certain cases on Safari, the app code utilizing `<auto-check>` might throw a abort error when trying to read the response. This error doesn't seem to happen on other browsers.

The hope is that this change will make sure that Safari will not raise a `AbortError` when trying to read a cloned, aborted response. But since this is really hard to test, we're not sure if this will actually fix the issue.

I'd like to ship this change as a prerelease on npm and update on dotcom and see if this change fixes it. If it does I can merge this and make a real release, if not I'll just revert the change in dotcom and close this PR.