### PR TITLE
Consider all 2xx responsed successful

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,7 @@ async function check(autoCheckElement: AutoCheckElement) {
       method: 'POST',
       body
     })
-    if (response.status === 200) {
+    if (response.ok) {
       processSuccess(response, input, autoCheckElement.required)
     } else {
       processFailure(response, input, autoCheckElement.required)


### PR DESCRIPTION
This line was previously

https://github.com/github/auto-check-element/blob/cbc4aed6297a105961c0b3cd2aef8def59dccf2d/src/index.js#L171

but got changed to 

https://github.com/github/auto-check-element/blob/1dea6c1a352d66f5768135b9ffbe931a2992f0c0/src/index.js#L197

We should consider all 200s successful.

https://developer.mozilla.org/en-US/docs/Web/API/Response/ok