### PR TITLE
Update reference to custom elements polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Browsers without native [custom element support][support] require a [polyfill][]
 - Microsoft Edge
 
 [support]: https://caniuse.com/#feat=custom-elementsv1
-[polyfill]: https://github.com/webcomponents/custom-elements
+[polyfill]: https://github.com/webcomponents/polyfills/tree/master/packages/custom-elements
 
 ## Development
 


### PR DESCRIPTION
This PR updates a link in README.md

The "webcomponents/custom-elements" polyfill has moved from its own repo to "webcomponents/polyfills"