### PR TITLE
Support alternative HTTP methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Note that in the following example the CSRF element is marked with the `data-csr
 - `csrf` is the [CSRF][] token for the posted form. It's available in the request body as a `authenticity_token` form parameter.
   - You can also supply the CSRF token via a child element. See [usage](#Usage) example.
 - `required` is a boolean attribute that requires the validation to succeed before the surrounding form may be submitted.
+- `http-method` defaults to `POST` where data is submitted as a POST with form data. You can set `GET` and the HTTP method used will be a get with url encoded params instead.
 
 ## Events
 

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -56,16 +56,8 @@
           },
           "members": [
             {
-              "kind": "method",
+              "kind": "field",
               "name": "setValidity",
-              "parameters": [
-                {
-                  "name": "message",
-                  "type": {
-                    "text": "string"
-                  }
-                }
-              ],
               "inheritedFrom": {
                 "name": "AutoCheckValidationEvent",
                 "module": "src/auto-check-element.ts"
@@ -92,16 +84,8 @@
           },
           "members": [
             {
-              "kind": "method",
+              "kind": "field",
               "name": "setValidity",
-              "parameters": [
-                {
-                  "name": "message",
-                  "type": {
-                    "text": "string"
-                  }
-                }
-              ],
               "inheritedFrom": {
                 "name": "AutoCheckValidationEvent",
                 "module": "src/auto-check-element.ts"
@@ -206,6 +190,14 @@
               "type": {
                 "text": "string"
               }
+            },
+            {
+              "kind": "field",
+              "name": "httpMethod",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true
             }
           ],
           "attributes": [

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -194,7 +194,7 @@ function setLoadingState(event: Event) {
   const state = states.get(autoCheckElement)
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (httpMethod === 'POST' && !csrf) || !state) {
+  if (!src || (this.httpMethod === 'POST' && !csrf) || !state) {
     return
   }
 
@@ -244,7 +244,7 @@ async function check(autoCheckElement: AutoCheckElement) {
   const state = states.get(autoCheckElement)
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (httpMethod === 'POST' && !csrf) || !state) {
+  if (!src || (this.httpMethod === 'POST' && !csrf) || !state) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
     }
@@ -259,12 +259,12 @@ async function check(autoCheckElement: AutoCheckElement) {
   }
 
   const body = new FormData()
-  if (httpMethod === 'POST') {
+  if (this.httpMethod === 'POST') {
     body.append(csrfField, csrf)
     body.append('value', input.value)
   } else {
-    url = new URL(src, window.location.origin)
-    url.search = new URLSearchParams({value: input.value}).toString()
+    this.url = new URL(src, window.location.origin)
+    this.url.search = new URLSearchParams({value: input.value}).toString()
   }
 
   input.dispatchEvent(new AutoCheckSendEvent(body))
@@ -281,7 +281,7 @@ async function check(autoCheckElement: AutoCheckElement) {
     const response = await fetchWithNetworkEvents(autoCheckElement, src, {
       credentials: 'same-origin',
       signal: state.controller.signal,
-      method: httpMethod,
+      method: this.httpMethod,
       body,
     })
     if (response.ok) {

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -194,7 +194,7 @@ function setLoadingState(event: Event) {
   const state = states.get(autoCheckElement)
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (this.httpMethod == 'POST' && !csrf) || !state) {
+  if (!src || (httpMethod === 'POST' && !csrf) || !state) {
     return
   }
 
@@ -244,7 +244,7 @@ async function check(autoCheckElement: AutoCheckElement) {
   const state = states.get(autoCheckElement)
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (this.httpMethod && !csrf) || !state) {
+  if (!src || (httpMethod && !csrf) || !state) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
     }
@@ -259,12 +259,12 @@ async function check(autoCheckElement: AutoCheckElement) {
   }
 
   const body = new FormData()
-  if (this.httpMethod) {
+  if (httpMethod === 'POST') {
     body.append(csrfField, csrf)
     body.append('value', input.value)
   } else {
-    url = new URL(src, window.location.origin);
-    url.search = new URLSearchParams({ value: input.value }).toString();
+    url = new URL(src, window.location.origin)
+    url.search = new URLSearchParams({value: input.value}).toString()
   }
 
   input.dispatchEvent(new AutoCheckSendEvent(body))

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -244,7 +244,7 @@ async function check(autoCheckElement: AutoCheckElement) {
   const state = states.get(autoCheckElement)
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (httpMethod && !csrf) || !state) {
+  if (!src || (httpMethod === 'POST' && !csrf) || !state) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
     }

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -263,7 +263,7 @@ async function check(autoCheckElement: AutoCheckElement) {
   }
 
   const body = new FormData()
-  if (isHttpPost) {
+  if (this.httpMethod) {
     body.append(csrfField, csrf)
     body.append('value', input.value)
   } else {

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -191,10 +191,11 @@ function setLoadingState(event: Event) {
 
   const src = autoCheckElement.src
   const csrf = autoCheckElement.csrf
+  const httpMethod = autoCheckElement.httpMethod
   const state = states.get(autoCheckElement)
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (this.httpMethod === 'POST' && !csrf) || !state) {
+  if (!src || (httpMethod === 'POST' && !csrf) || !state) {
     return
   }
 
@@ -242,9 +243,10 @@ async function check(autoCheckElement: AutoCheckElement) {
   const src = autoCheckElement.src
   const csrf = autoCheckElement.csrf
   const state = states.get(autoCheckElement)
+  const httpMethod = autoCheckElement.httpMethod
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (this.httpMethod === 'POST' && !csrf) || !state) {
+  if (!src || (httpMethod === 'POST' && !csrf) || !state) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
     }
@@ -259,7 +261,7 @@ async function check(autoCheckElement: AutoCheckElement) {
   }
 
   const body = new FormData()
-  if (this.httpMethod === 'POST') {
+  if (httpMethod === 'POST') {
     body.append(csrfField, csrf)
     body.append('value', input.value)
   } else {
@@ -281,7 +283,7 @@ async function check(autoCheckElement: AutoCheckElement) {
     const response = await fetchWithNetworkEvents(autoCheckElement, src, {
       credentials: 'same-origin',
       signal: state.controller.signal,
-      method: this.httpMethod,
+      method: httpMethod,
       body,
     })
     if (response.ok) {

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -180,10 +180,6 @@ export class AutoCheckElement extends HTMLElement {
   get httpMethod(): string {
     return this.getAttribute('http-method') || 'POST'
   }
-
-  get isHttpPost(): bool {
-    return this.httpMethod == 'POST'
-  }
 }
 
 function setLoadingState(event: Event) {

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -267,7 +267,7 @@ async function check(autoCheckElement: AutoCheckElement) {
     body.append(csrfField, csrf)
     body.append('value', input.value)
   } else {
-    url = new URL(src);
+    url = new URL(src, window.location.origin);
     url.search = new URLSearchParams({ value: input.value }).toString();
   }
 

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -248,7 +248,7 @@ async function check(autoCheckElement: AutoCheckElement) {
   const state = states.get(autoCheckElement)
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (isHttpPost && !csrf) || !state) {
+  if (!src || (this.httpMethod && !csrf) || !state) {
     if (autoCheckElement.required) {
       input.setCustomValidity('')
     }

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -198,7 +198,7 @@ function setLoadingState(event: Event) {
   const state = states.get(autoCheckElement)
 
   // If some attributes are missing we want to exit early and make sure that the element is valid.
-  if (!src || (isHttpPost && !csrf) || !state) {
+  if (!src || (this.httpMethod == 'POST' && !csrf) || !state) {
     return
   }
 

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -219,6 +219,9 @@ function makeAbortController() {
 }
 
 async function fetchWithNetworkEvents(el: Element, url: string, options: RequestInit): Promise<Response> {
+  if (options.method === 'GET') {
+    delete options.body
+  }
   try {
     const response = await fetch(url, options)
     el.dispatchEvent(new Event('load'))

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -261,12 +261,12 @@ async function check(autoCheckElement: AutoCheckElement) {
   }
 
   const body = new FormData()
+  const url = new URL(src, window.location.origin)
   if (httpMethod === 'POST') {
     body.append(csrfField, csrf)
     body.append('value', input.value)
   } else {
-    this.url = new URL(src, window.location.origin)
-    this.url.search = new URLSearchParams({value: input.value}).toString()
+    url.search = new URLSearchParams({value: input.value}).toString()
   }
 
   input.dispatchEvent(new AutoCheckSendEvent(body))
@@ -280,7 +280,7 @@ async function check(autoCheckElement: AutoCheckElement) {
   state.controller = makeAbortController()
 
   try {
-    const response = await fetchWithNetworkEvents(autoCheckElement, src, {
+    const response = await fetchWithNetworkEvents(autoCheckElement, url.toString(), {
       credentials: 'same-origin',
       signal: state.controller.signal,
       method: httpMethod,

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -12,6 +12,11 @@ type State = {
   controller: Controller | null
 }
 
+enum AllowedHttpMethods {
+  GET = 'GET',
+  POST = 'POST',
+}
+
 const states = new WeakMap<AutoCheckElement, State>()
 
 class AutoCheckEvent extends Event {
@@ -178,7 +183,7 @@ export class AutoCheckElement extends HTMLElement {
   }
 
   get httpMethod(): string {
-    return this.getAttribute('http-method') || 'POST'
+    return AllowedHttpMethods[this.getAttribute('http-method') as keyof typeof AllowedHttpMethods] || 'POST'
   }
 }
 

--- a/test/auto-check.js
+++ b/test/auto-check.js
@@ -114,6 +114,35 @@ describe('auto-check element', function () {
     })
   })
 
+  describe('using HTTP GET', function () {
+    let checker
+    let input
+
+    beforeEach(function () {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <auto-check src="/success" http-method="GET" required>
+          <input>
+        </auto-check>`
+      document.body.append(container)
+
+      checker = document.querySelector('auto-check')
+      input = checker.querySelector('input')
+    })
+
+    afterEach(function () {
+      document.body.innerHTML = ''
+      checker = null
+      input = null
+    })
+
+    it('validates input with successful server response with GET', async function () {
+      triggerInput(input, 'hub')
+      await once(input, 'auto-check-complete')
+      assert.isTrue(input.checkValidity())
+    })
+  })
+
   describe('network lifecycle events', function () {
     let checker
     let input

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -19,7 +19,7 @@ export default {
   middleware: [
     async ({request, response}, next) => {
       const {method, path} = request
-      if (method === 'POST') {
+      if (method === 'POST' || method === 'GET') {
         if (path.startsWith('/fail')) {
           response.status = 422
           // eslint-disable-next-line i18n-text/no-en


### PR DESCRIPTION
This change proposed supporting the use of alternative HTTP methods.

For example, now a user can define `http-method=GET` and then component will issue a `GET` request using encoded query params instead. All values other than POST will use this new approach. The default remains POST.