### PR TITLE
Align behavior with Primer guidance behind only-validate-on-blur toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# TODO: Should we switch back out of always-on validation once the input passes validation, or stay in always-on?
+
 # &lt;auto-check&gt; element
 
 An input element that validates its value against a server endpoint.
@@ -157,6 +159,9 @@ Browsers without native [custom element support][support] require a [polyfill][]
 npm install
 npm test
 ```
+
+TODO: Add note about uncommenting line at bottom of examples for local development
+Input something other than 422 for error response?
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ npm install
 npm test
 ```
 
-TODO: Add note about uncommenting line at bottom of examples for local development
+For local development, uncomment the line at the bottom of `examples/index` and serve the page using `npx serve`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# TODO: Should we switch back out of always-on validation once the input passes validation, or stay in always-on?
-
 # &lt;auto-check&gt; element
 
 An input element that validates its value against a server endpoint.
@@ -161,7 +159,6 @@ npm test
 ```
 
 TODO: Add note about uncommenting line at bottom of examples for local development
-Input something other than 422 for error response?
 
 ## License
 

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -201,7 +201,7 @@
             },
             {
               "kind": "field",
-              "name": "validateAfterFirstBlur",
+              "name": "onlyValidateOnBlur",
               "type": {
                 "text": "boolean"
               },
@@ -209,11 +209,10 @@
             },
             {
               "kind": "field",
-              "name": "shouldValidate",
+              "name": "validateOnKeystroke",
               "type": {
                 "text": "boolean"
-              },
-              "readonly": true
+              }
             }
           ],
           "attributes": [

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -198,6 +198,22 @@
                 "text": "string"
               },
               "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "validateAfterFirstBlur",
+              "type": {
+                "text": "boolean"
+              },
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "shouldValidate",
+              "type": {
+                "text": "boolean"
+              },
+              "readonly": true
             }
           ],
           "attributes": [

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -201,18 +201,18 @@
             },
             {
               "kind": "field",
+              "name": "validateOnKeystroke",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "kind": "field",
               "name": "onlyValidateOnBlur",
               "type": {
                 "text": "boolean"
               },
               "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "validateOnKeystroke",
-              "type": {
-                "text": "boolean"
-              }
             }
           ],
           "attributes": [

--- a/examples/index.html
+++ b/examples/index.html
@@ -108,7 +108,7 @@
       }
     </script>
 
-    <script type="module" src="https://unpkg.com/@github/auto-check-element@latest"></script>
-    <!-- <script type="module" src="../dist/bundle.js" defer></script> -->
+    <!-- <script type="module" src="https://unpkg.com/@github/auto-check-element@latest"></script> -->
+    <script type="module" src="../dist/bundle.js" defer></script>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -38,9 +38,9 @@
         <button value="2" name="form">submit</button>
       </form>
 
-      <h2>only-validate-on-blur</h2>
+      <h2>only-validate-on-blur with custom validity messages</h2>
       <h2 tabindex="-1" id="success3" class="success" hidden>Your submission was successful</h2>
-      <form>
+      <form id="custom2">
         <p>All fields marked with * are required</p>
 
         <label for="simple-field2">Desired username*:</label>
@@ -86,7 +86,7 @@
         })
 
         form.addEventListener('auto-check-start', () => {
-          if (form.id === 'custom') {
+          if (form.id.includes('custom')) {
             const {setValidity} = event.detail
             setValidity('🔍 Checking validity...')
           }
@@ -96,7 +96,7 @@
           state.textContent = 'succeeded'
         })
         form.addEventListener('auto-check-error', event => {
-          if (form.id === 'custom') {
+          if (form.id.includes('custom')) {
             const {setValidity} = event.detail
             setValidity('🚫 Something went wrong. Please try again')
           }

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,7 +22,7 @@
         <button value="1" name="form">submit</button>
       </form>
 
-      <!-- <h2>Form that has custom validity messages</h2>
+      <h2>Form that has custom validity messages</h2>
       <p>Input 422 for an error response.</p>
       <h2 tabindex="-1" id="success2" class="success" hidden>Your submission was successful</h2>
       <form id="custom">
@@ -34,13 +34,13 @@
           <p id="state2" aria-atomic="true" aria-live="polite" class="state"></p>
         </auto-check>
         <button value="2" name="form">submit</button>
-      </form> -->
+      </form>
 
-      <h2>validate-after-first-blur</h2>
+      <h2>only-validate-on-blur</h2>
       <h2 tabindex="-1" id="success3" class="success" hidden>Your submission was successful</h2>
       <form>
         <label for="simple-field2">Desired username*:</label>
-        <auto-check csrf="foo" src="/demo" required validate-after-first-blur>
+        <auto-check csrf="foo" src="/demo" required only-validate-on-blur>
           <input id="simple-field2" autofocus name="foo" required aria-describedby="state3" />
           <p id="state3" aria-atomic="true" aria-live="polite" class="state"></p>
         </auto-check>

--- a/examples/index.html
+++ b/examples/index.html
@@ -41,6 +41,8 @@
       <h2>only-validate-on-blur</h2>
       <h2 tabindex="-1" id="success3" class="success" hidden>Your submission was successful</h2>
       <form>
+        <p>All fields marked with * are required</p>
+
         <label for="simple-field2">Desired username*:</label>
         <auto-check csrf="foo" src="/demo" required only-validate-on-blur>
           <input id="simple-field2" autofocus name="foo" required aria-describedby="state3" />

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,9 +11,11 @@
   <body>
     <main>
       <h1>auto-check-element</h1>
-      <h2>old behavior</h2>
+      <h2>Simple form</h2>
       <h2 tabindex="-1" id="success1" class="success" hidden>Your submission was successful</h2>
       <form>
+        <p>All fields marked with * are required</p>
+
         <label for="simple-field">Desired username*:</label>
         <auto-check csrf="foo" src="/demo" required>
           <input id="simple-field" autofocus name="foo" required aria-describedby="state1" />
@@ -104,7 +106,7 @@
       }
     </script>
 
-    <!-- <script type="module" src="https://unpkg.com/@github/auto-check-element@latest"></script> -->
-    <script type="module" src="../dist/bundle.js" defer></script>
+    <script type="module" src="https://unpkg.com/@github/auto-check-element@latest"></script>
+    <!-- <script type="module" src="../dist/bundle.js" defer></script> -->
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,12 +11,9 @@
   <body>
     <main>
       <h1>auto-check-element</h1>
-      <h2>Simple form</h2>
-      <p>Input 422 for an error response.</p>
+      <h2>old behavior</h2>
       <h2 tabindex="-1" id="success1" class="success" hidden>Your submission was successful</h2>
       <form>
-        <p>All fields marked with * are required</p>
-
         <label for="simple-field">Desired username*:</label>
         <auto-check csrf="foo" src="/demo" required>
           <input id="simple-field" autofocus name="foo" required aria-describedby="state1" />
@@ -25,7 +22,7 @@
         <button value="1" name="form">submit</button>
       </form>
 
-      <h2>Form that has custom validity messages</h2>
+      <!-- <h2>Form that has custom validity messages</h2>
       <p>Input 422 for an error response.</p>
       <h2 tabindex="-1" id="success2" class="success" hidden>Your submission was successful</h2>
       <form id="custom">
@@ -37,6 +34,17 @@
           <p id="state2" aria-atomic="true" aria-live="polite" class="state"></p>
         </auto-check>
         <button value="2" name="form">submit</button>
+      </form> -->
+
+      <h2>validate-after-first-blur</h2>
+      <h2 tabindex="-1" id="success3" class="success" hidden>Your submission was successful</h2>
+      <form>
+        <label for="simple-field2">Desired username*:</label>
+        <auto-check csrf="foo" src="/demo" required validate-after-first-blur>
+          <input id="simple-field2" autofocus name="foo" required aria-describedby="state3" />
+          <p id="state3" aria-atomic="true" aria-live="polite" class="state"></p>
+        </auto-check>
+        <button value="3" name="form">submit</button>
       </form>
     </main>
 
@@ -96,7 +104,7 @@
       }
     </script>
 
-    <script type="module" src="https://unpkg.com/@github/auto-check-element@latest"></script>
-    <!-- <script type="module" src="../dist/index.js" defer></script> -->
+    <!-- <script type="module" src="https://unpkg.com/@github/auto-check-element@latest"></script> -->
+    <script type="module" src="../dist/bundle.js" defer></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2235,9 +2235,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001480",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz",
-            "integrity": "sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==",
+            "version": "1.0.30001683",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001683.tgz",
+            "integrity": "sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==",
             "dev": true,
             "funding": [
                 {

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -101,10 +101,6 @@ export class AutoCheckElement extends HTMLElement {
     const input = this.input
     if (!input) return
 
-    if (!this.onlyValidateOnBlur) {
-      this.setAttribute('validate-on-keystroke', '')
-    }
-
     const checker = debounce(check.bind(null, this), 300)
     const state = {check: checker, controller: null}
     states.set(this, state)

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -221,8 +221,8 @@ function handleChange(checker: () => void, event: Event) {
     (event.type === 'blur' && autoCheckElement.onlyValidateOnBlur) || // Only validate on blur if only-validate-on-blur is set
     (autoCheckElement.onlyValidateOnBlur && autoCheckElement.validateOnKeystroke) // Only validate on key inputs in only-validate-on-blur mode if validate-on-keystroke is set (when input is invalid)
   ) {
-    checker()
     setLoadingState(event)
+    checker()
   }
 }
 

--- a/src/auto-check-element.ts
+++ b/src/auto-check-element.ts
@@ -188,11 +188,6 @@ export class AutoCheckElement extends HTMLElement {
     return AllowedHttpMethods[this.getAttribute('http-method') as keyof typeof AllowedHttpMethods] || 'POST'
   }
 
-  get onlyValidateOnBlur(): boolean {
-    const value = this.getAttribute('only-validate-on-blur')
-    return value === 'true' || value === ''
-  }
-
   set validateOnKeystroke(enabled: boolean) {
     if (enabled) {
       this.setAttribute('validate-on-keystroke', '')
@@ -203,6 +198,11 @@ export class AutoCheckElement extends HTMLElement {
 
   get validateOnKeystroke(): boolean {
     const value = this.getAttribute('validate-on-keystroke')
+    return value === 'true' || value === ''
+  }
+
+  get onlyValidateOnBlur(): boolean {
+    const value = this.getAttribute('only-validate-on-blur')
     return value === 'true' || value === ''
   }
 }

--- a/test/auto-check.js
+++ b/test/auto-check.js
@@ -22,6 +22,36 @@ describe('auto-check element', function () {
     })
   })
 
+  describe('when validate-after-first-blur is true', function () {
+    let checker
+    let input
+
+    beforeEach(function () {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <auto-check csrf="foo" src="/success" validate-after-first-blur>
+          <input>
+        </auto-check>`
+      document.body.append(container)
+
+      checker = document.querySelector('auto-check')
+      input = checker.querySelector('input')
+    })
+
+    it('does not emit on initial input change', async function () {
+      const events = []
+      input.addEventListener('auto-check-start', event => events.push(event.type))
+      triggerInput(input, 'hub')
+      assert.deepEqual(events, [])
+    })
+
+    afterEach(function () {
+      document.body.innerHTML = ''
+      checker = null
+      input = null
+    })
+  })
+
   describe('required attribute', function () {
     let checker
     let input


### PR DESCRIPTION
## Problem

Us folks working on improving the GitHub.com signup flow are looking to address a UX/a11y concern with the `auto-check` element: it validates on _every_ keystroke.

- This UX is frustrating to users who may not have provided a _complete_ input yet, such as a partial email address in our case. 
- This UX is frustrating to screen reader users who are spammed with announcements on every keystroke.

## Proposed solution

We should modify the behavior to align with https://primer.style/ui-patterns/forms/overview#inline-validation, which states:

> Don't attempt to validate an input before the user is done with it. Validation may be performed as the user is typing or making their selection, but only after the first time the input has been validated and the input is in an invalid state. This gives the user early positive feedback by removing the error if the user makes a change that fixes it.

I've done so behind an opt-in `only-validate-on-blur` (anyone got a better name?) toggle. My hope is to ship this change and then test it across our use-cases on GitHub.com. If it proves to be viable in all cases, I'll make the case to change the default value to true in a breaking release ❤️ 

I've validated this proposal with both [Primer](https://github.slack.com/archives/CSGAVNZ19/p1732119581811869) and [a11y](https://github.slack.com/archives/C05539DELV7/p1732552112611769) folks.

## Notes for reviewers

Most of my notes are left as code comments: I found this tricky to test at times but was able to figure out coverage for most of it. I did exercise it locally as much as possible. 

I did run into a little bit of friction when setting up my local development environment, so I've included a few small docs updates as well. 

Closes: https://github.com/github/auto-check-element/issues/75