### PR TITLE
do not re-validate on blur if already validated

### DIFF
--- a/test/auto-check.js
+++ b/test/auto-check.js
@@ -60,6 +60,18 @@ describe('auto-check element', function () {
       assert.deepEqual(events, ['auto-check-start'])
     })
 
+    it('does not emit on blur if input has not changed after initial blur', async function () {
+      const events = []
+      input.addEventListener('auto-check-start', event => events.push(event.type))
+      triggerInput(input, 'hub')
+      triggerBlur(input)
+
+      await once(input, 'auto-check-complete')
+      triggerBlur(input)
+
+      assert.deepEqual(events, ['auto-check-start'])
+    })
+
     it('emits on input change if input is invalid after blur', async function () {
       const events = []
       input.addEventListener('auto-check-start', event => events.push(event.type))
@@ -69,6 +81,23 @@ describe('auto-check element', function () {
       triggerBlur(input)
       await once(input, 'auto-check-complete')
       triggerInput(input, 'hub2')
+      triggerInput(input, 'hub3')
+
+      assert.deepEqual(events, ['auto-check-start', 'auto-check-start', 'auto-check-start'])
+    })
+
+    it('does not emit on blur if input is invalid', async function () {
+      const events = []
+      input.addEventListener('auto-check-start', event => events.push(event.type))
+
+      checker.src = '/fail'
+      triggerInput(input, 'hub')
+      triggerBlur(input)
+      await once(input, 'auto-check-complete')
+
+      triggerInput(input, 'hub2')
+      triggerBlur(input)
+
       triggerInput(input, 'hub3')
 
       assert.deepEqual(events, ['auto-check-start', 'auto-check-start', 'auto-check-start'])


### PR DESCRIPTION
In testing https://github.com/github/auto-check-element/pull/76 in GitHub.com, we discovered cases where input would be re-validated on blur even if the input had not changed. This PR updates our valid and invalid code paths to only validate on blur if the input has not otherwise been already validated.

(for Hubbers) See internal issue: https://github.com/github/new-user-experience/issues/242, task #1.