### PR TITLE
reference CDN in examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -108,7 +108,7 @@
       }
     </script>
 
-    <!-- <script type="module" src="https://unpkg.com/@github/auto-check-element@latest"></script> -->
-    <script type="module" src="../dist/bundle.js" defer></script>
+    <script type="module" src="https://unpkg.com/@github/auto-check-element@latest"></script>
+    <!-- <script type="module" src="../dist/bundle.js" defer></script> -->
   </body>
 </html>


### PR DESCRIPTION
In a previous PR, I accidentally committed a change that broke the examples on the demo site. I've reverted that regression here ❤️ 